### PR TITLE
notation errors

### DIFF
--- a/paper/iacr.tex
+++ b/paper/iacr.tex
@@ -107,7 +107,7 @@ Note in particular that Pedersen matrix commitments are similarly homomorphic.
 For integers or field elements $i,j$, the Kronecker delta function $\delta(i,j)$ evaluates to $1$ if $i=j$ and $0$ otherwise, where the output is taken to be in the appropriate set.
 
 We sometimes use index subscript notation of the form $i_j$ to indicate the $j$ digit of $i$, where such a decomposition of $i$ is taken base $n$ with padded length $m$:
-$$\sum_{j=0}^m i_j n^j = i$$
+$$\sum_{j=0}^{m-1} i_j n^j = i$$
 This notation will be specified explicitly where confusion may occur.
 
 

--- a/paper/iacr.tex
+++ b/paper/iacr.tex
@@ -245,7 +245,7 @@ From the $3$-special soundness in \cite{bootle} and $m > 1$ we have valid extrac
 $$f^{(e)}_{j,i} = \sigma_{j,i}\xi_e + a_{j,i}$$
 for all $e \in [0,m]$.
 Using the extracted values, compute
-$$p_k(\xi) \equiv \prod_{j=0}^{m-1} \left( \sigma_{j,k}\xi + a_{j,k} \right)$$
+$$p_k(\xi) \equiv \prod_{j=0}^{m-1} \left( \sigma_{j,k_j}\xi + a_{j,k_j} \right)$$
 for all $k \in [0,N)$.
 Extraction of $\{\sigma_{j,i}\}_{j,i=0}^{m-1,n-1}$ immediately yields the signing index $l$.
 

--- a/paper/iacr.tex
+++ b/paper/iacr.tex
@@ -129,11 +129,11 @@ $\underline{\mathcal{P}_{\text{link}}(\{M_i\},J;(l,r)):}$
 \begin{itemize}
 \item Select random $r_A \in \F$ and $\left\{a_{j,i}\right\}_{i=1,j=0}^{n-1,m-1} \subset \F$.
 Set $$\{a_{j,0}\}_{j=0}^{m-1} \equiv -\sum_{i=1}^{n-1} a_{j,i}$$ and define $A \equiv \com(a,r_A)$.
-\item Define $\left\{\sigma_{j,i}\right\}_{i,j=0}^{n-1,j-1} \subset \F$ such that $\sigma_{j,i} \equiv \delta\left(l_j,i\right)$ (using our decomposition notation), and choose random $r_B \in \F$.
+\item Define $\left\{\sigma_{j,i}\right\}_{i,j=0}^{n-1,m-1} \subset \F$ such that $\sigma_{j,i} \equiv \delta\left(l_j,i\right)$ (using our decomposition notation), and choose random $r_B \in \F$.
 Define $B \equiv \com(\sigma,r_B)$.
 \item Select random $r_C \in \F$, and define $C \equiv \com(a(1-2\sigma), r_C)$.
 \item Select random $r_D \in \F$, and define $D \equiv \com(-a^2, r_D)$.
-\item Define coefficients $\left\{p_{k,j}\right\}_{k,j=0}^{N-1,m-1}$ such that $$p_k(x) \equiv \prod_{j=0}^{m-1} \left( \sigma_{j,k}x + a_{j,k} \right) = \delta\left(l,k\right)x^m + \sumj p_{k,j}x^j$$ for all $k \in [0,N)$ (using our decomposition notation).
+\item Define coefficients $\left\{p_{k,j}\right\}_{k,j=0}^{N-1,m-1}$ such that $$p_k(x) \equiv \prod_{j=0}^{m-1} \left( \sigma_{j,k_j}x + a_{j,k_j} \right) = \delta\left(l,k\right)x^m + \sumj p_{k,j}x^j$$ for all $k \in [0,N)$ (using our decomposition notation).
 \item Select random $\left\{\rho_j\right\}_{j=0}^{m-1} \subset \F$.
 \item Define $\{X_j\}_{j=0}^{m-1} \subset \G$ such that: $$X_j \equiv \sumk p_{k,j}M_k + \rho_jG$$
 \item Define $\{Y_j\}_{j=0}^{m-1} \subset \G$ such that: $$Y_j \equiv U \sumk p_{k,j}+ \rho_jJ$$


### PR DESCRIPTION
Hi, I'm currently trying to understand the Triptych paper and I think I've stumbled upon some minor typos / notation errors:

On page 4, in the definition of the Sigma protocol for `R_link` (Figure 1), `p_k(x)` is defined as:

```
p_k(x) = \prod_{j=0}^{m-1} ( \sigma_{j,k}x + a_{j,k} )
```
![](https://render.githubusercontent.com/render/math?math=p_k(x)%20%3D%20%5Cprod_%7Bj%3D0%7D%5E%7Bm-1%7D%20(%20%5Csigma_%7Bj%2Ck%7Dx%20%2B%20a_%7Bj%2Ck%7D%20))

However, for both `\sigma` and `a` the second index is only defined for the range `0..n-1`, whereas `k \in [0,N)` (with `N=n^m`).

From context and by comparing it to equation (1) in section 3 of the *"One-out-of-Many Proofs"*[1] paper, that this step of the protocol appears to be based on, my best guess is, that it should be `k_j` instead of `k`, so:

```
p_k(x) = \prod_{j=0}^{m-1} ( \sigma_{j,k_j}x + a_{j,k_j} )
```
![](https://render.githubusercontent.com/render/math?math=p_k(x)%20%3D%20%5Cprod_%7Bj%3D0%7D%5E%7Bm-1%7D%20(%20%5Csigma_%7Bj%2Ck_j%7Dx%20%2B%20a_%7Bj%2Ck_j%7D%20))

That way the coefficient for the `x^m` term would be

```
\prod_{j=0}^{m-1} \sigma_{j,k_j} = \prod_{j=0}^{m-1} \delta(l_j,k_j) = \delta(l,k)
```
![](https://render.githubusercontent.com/render/math?math=%5Cprod_%7Bj%3D0%7D%5E%7Bm-1%7D%20%5Csigma_%7Bj%2Ck_j%7D%20%3D%20%5Cprod_%7Bj%3D0%7D%5E%7Bm-1%7D%20%5Cdelta(l_j%2Ck_j)%20%3D%20%5Cdelta(l%2Ck))

so it works out with the right hand side of the equation / definition for `p_k(x)`.

Is my guess here correct, or am I completely misunderstanding what `k` is in this context, or how `\sigma` and `a` are defined?

&nbsp;

---

[1] https://eprint.iacr.org/2014/764.pdf Jens Groth and Markulf Kohlweiss. *One-out-of-Many Proofs: Or How to Leak a Secret and Spend a Coin*. Cryptology ePrint Archive, Report 2014/764. 2014.